### PR TITLE
[IDL-123] stop and resume bottling plant consumers when iterator is expired

### DIFF
--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end

--- a/lib/kcl/worker.rb
+++ b/lib/kcl/worker.rb
@@ -116,20 +116,22 @@ class Kcl::Worker
 
       shard = checkpointer.lease(shard, @id)
 
-      thread_group.add(Thread.new do
-        begin
-          consumer = Kcl::Workers::Consumer.new(
-            shard,
-            @record_processor_factory.create_processor,
-            kinesis,
-            checkpointer
-          )
-          consumer.consume!
-        ensure
-          shard = checkpointer.remove_lease_owner(shard)
-          Kcl.logger.debug("Finish to consume shard at shard_id: #{shard_id}")
+      thread_group.add(
+        Thread.new do
+          begin
+            consumer = Kcl::Workers::Consumer.new(
+              shard,
+              @record_processor_factory.create_processor,
+              kinesis,
+              checkpointer
+            )
+            consumer.consume!
+          ensure
+            shard = checkpointer.remove_lease_owner(shard)
+            Kcl.logger.debug("Finish to consume shard at shard_id: #{shard_id}")
+          end
         end
-        end)
+      )
     end
     thread_group.list.each(&:join)
   end

--- a/lib/kcl/worker.rb
+++ b/lib/kcl/worker.rb
@@ -126,13 +126,13 @@ class Kcl::Worker
               checkpointer
             )
             consumer.consume!
-          rescue AWS::Kinesis::Errors::ExpiredIteratorException => e
+          rescue StandardError => e
             Thread.current.group.list.each do |thread|
-              next if thread.object_id = Thread.current.object_id
+              next if thread.object_id == Thread.current.object_id
 
               thread.kill
             end
-
+            Kcl.logger.debug("Killed threads due to error #{e.inspect}, Thread: #{Thread.current.object_id}")
             raise e
           ensure
             shard = checkpointer.remove_lease_owner(shard)

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -29,6 +29,14 @@ module Kcl::Workers
 
         shard_iterator = result[:next_shard_iterator]
         break if result[:records].empty? && result[:millis_behind_latest] == 0
+      rescue AWS::Kinesis::Errors::ExpiredIteratorException => e
+        Thread.current.group.list.each do |thread|
+          next if thread.object_id = Thread.current.object_id
+
+          thread.kill
+        end
+
+        raise e
       end
 
       shutdown_reason = shard_iterator.nil? ?

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -29,14 +29,6 @@ module Kcl::Workers
 
         shard_iterator = result[:next_shard_iterator]
         break if result[:records].empty? && result[:millis_behind_latest] == 0
-      rescue AWS::Kinesis::Errors::ExpiredIteratorException => e
-        Thread.current.group.list.each do |thread|
-          next if thread.object_id = Thread.current.object_id
-
-          thread.kill
-        end
-
-        raise e
       end
 
       shutdown_reason = shard_iterator.nil? ?


### PR DESCRIPTION
Rather than catching the expired lease iterator error in the consumer and trying to reset/renew the lease, kill peer threads and exit, allowing the worker's periodic timer to resume new threads (this also resyncs shards, in case one were added or removed by dynamic allocation we'll begin processing it).

The original problem was that once a thread had stopped,  other threads with work to perform would stay alive indefinitely, preventing the worker from starting additional threads.

This led to a situation where a stalled shard would allow work to pile up, while a shard with a backlog was drained. By the time the live shard's backlog had drained, a backlog had accumulated in the other threads.

The current proposed change does not address the situation with uneven draining but no exception seen.

#4 is probably a better solution and should be considered first.