### PR TITLE
[IDL-123] Handle Kinesis errors and balance backlogs 

### DIFF
--- a/lib/kcl/config.rb
+++ b/lib/kcl/config.rb
@@ -7,6 +7,7 @@ class Kcl::Config
     :dynamodb_read_capacity,
     :dynamodb_write_capacity,
     :dynamodb_failover_seconds,
+    :idle_thread_check_frequency,
     :kinesis_endpoint,
     :kinesis_stream_name,
     :logger,
@@ -26,6 +27,7 @@ class Kcl::Config
     @dynamodb_read_capacity  = 10
     @dynamodb_write_capacity = 10
     @dynamodb_failover_seconds = 10
+    @idle_thread_check_frequency = 10
     @kinesis_endpoint        = 'https://localhost:4566'
     @kinesis_stream_name     = nil
     @logger                  = nil

--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -23,7 +23,11 @@ module Kcl::Workers
       shard_iterator = start_shard_iterator
 
       loop do
+        if check_peers?
+          break if idle_peers?
+        end
         result = safe_get_records(shard_iterator)
+
         records_input = create_records_input(
           result[:records],
           result[:millis_behind_latest],
@@ -80,6 +84,7 @@ module Kcl::Workers
       )
     end
 
+
     def safe_get_records(shard_iterator, count = LEASE_RETRY)
       @kinesis.get_records(shard_iterator)
     rescue Aws::Kinesis::Errors::ExpiredIteratorException => e
@@ -92,6 +97,13 @@ module Kcl::Workers
       @shard = @checkpointer.lease(@shard, assigned_to)
       shard_iterator = start_shard_iterator
       safe_get_records(shard_iterator, count - 1)
+
+    def check_peers?
+      Random.rand(Kcl.config.idle_thread_check_frequency).zero?
+    end
+
+    def idle_peers?
+      Thread.current.group.list.any?(&:stop?)
     end
   end
 end

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -21,7 +21,7 @@ module Kcl::Workers
       shard_iterator = start_shard_iterator
 
       loop do
-        result = @kinesis.get_records(shard_iterator)
+        result = safe_get_records(shard_iterator)
         records_input = create_records_input(
           result[:records],
           result[:millis_behind_latest],
@@ -79,8 +79,8 @@ module Kcl::Workers
     end
 
     def safe_get_records(shard_iterator, count=LEASE_RETRY)
-      @klnesis.get_records(shard_iterator)
-    rescue AWS::Kinesis::Errors::ExpiredIteratorException => e
+      @kinesis.get_records(shard_iterator)
+    rescue Aws::Kinesis::Errors::ExpiredIteratorException => e
       raise e if count == 0
 
       Kcl.logger.debug("Received expired iterator exception: #{e.inspect}")

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -84,7 +84,6 @@ module Kcl::Workers
       )
     end
 
-
     def safe_get_records(shard_iterator, count = LEASE_RETRY)
       @kinesis.get_records(shard_iterator)
     rescue Aws::Kinesis::Errors::ExpiredIteratorException => e
@@ -96,7 +95,9 @@ module Kcl::Workers
       @shard = @checkpointer.fetch_checkpoint(@shard)
       @shard = @checkpointer.lease(@shard, assigned_to)
       shard_iterator = start_shard_iterator
+      Kcl.logger.debug("Refreshed shard iterator, calling get records again")
       safe_get_records(shard_iterator, count - 1)
+    end
 
     def check_peers?
       Random.rand(Kcl.config.idle_thread_check_frequency).zero?

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-kinesis'
+
 module Kcl::Workers
   # Shard : Consumer = 1 : 1
   # - get records from stream

--- a/spec/workers/consumer_spec.rb
+++ b/spec/workers/consumer_spec.rb
@@ -67,4 +67,48 @@ RSpec.describe Kcl::Workers::Consumer do
       end
     end
   end
+
+  describe '#safe_get_records' do
+    let(:target_shard) { shard }
+    let(:iterator) { consumer.start_shard_iterator }
+    let(:expected_error) { Aws::Kinesis::Errors::ExpiredIteratorException.new('context', 'message', 'data') }
+
+    it 'returns response from kinesis' do
+      allow(kinesis).to receive(:get_records).and_call_original
+
+      consumer.safe_get_records(iterator)
+
+      expect(kinesis).to have_received(:get_records).once
+    end
+
+    it 'raises errors when retry count is exhausted' do
+      allow(kinesis).to receive(:get_records).and_raise(expected_error)
+
+      expect { consumer.safe_get_records(iterator) }.to raise_error(expected_error)
+
+      expect(kinesis).to have_received(:get_records).exactly(4).times
+    end
+
+    it 'resets the shard iterator when error occurs' do
+      one_time_error = true
+      original_get_records = kinesis.method(:get_records)
+
+      allow(checkpointer).to receive(:lease).and_call_original
+
+      # raise an error, then call original method
+      allow(kinesis).to receive(:get_records) do |iterator|
+        if one_time_error
+          one_time_error = false
+          raise expected_error
+        else
+          original_get_records.call(iterator)
+        end
+      end
+
+      consumer.safe_get_records(iterator, 1)
+
+      expect(kinesis).to have_received(:get_records).twice
+      expect(checkpointer).to have_received(:lease).once
+    end
+  end
 end


### PR DESCRIPTION
This brings in the changes in #4 (threads should stop eventually if there are other idle threads, allowing shard refresh and all threads to restart, preventing a backlog on a single thread from blocking work from starting on other shards) and #5 (if processing records exceeds the 300s default iterator timeout and a lease exception is received, release the existing lease, and reacquire one automatically, rather than stopping the shard consumer with an error). 

This will be local kcl-rb version 1.0.3

The recovery logic was tested successfully in staging by introducing a five minute sleep immediately after starting the iterator, and before calling get_records the first time, ensuring we stepped through the fallback/recovery code and then received a batch of records for processing.

https://teamprovi.atlassian.net/browse/IDL-123

Tests pass locally

```
kcl-rb $ bundle exec rspec 
...............

Finished in 4.18 seconds (files took 0.8706 seconds to load)
15 examples, 0 failures
```