### PR TITLE
Prevent comparison of string with number

### DIFF
--- a/lib/kcl/checkpointer.rb
+++ b/lib/kcl/checkpointer.rb
@@ -64,7 +64,7 @@ class Kcl::Checkpointer
       "#{DYNAMO_DB_LEASE_OWNER_KEY}" => shard.assigned_to,
       "#{DYNAMO_DB_LEASE_TIMEOUT_KEY}" => shard.lease_timeout.to_s
     }
-    if shard.parent_shard_id > 0
+    if shard.parent_shard_id != 0
       item[DYNAMO_DB_PARENT_SHARD_KEY] = shard.parent_shard_id
     end
 
@@ -117,7 +117,7 @@ class Kcl::Checkpointer
     if shard.checkpoint != ''
       item[DYNAMO_DB_CHECKPOINT_SEQUENCE_NUMBER_KEY] = shard.checkpoint
     end
-    if shard.parent_shard_id > 0
+    if shard.parent_shard_id != 0
       item[DYNAMO_DB_PARENT_SHARD_KEY] = shard.parent_shard_id
     end
 

--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end


### PR DESCRIPTION
When not nil, a [kinesis shard](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/Kinesis/Types/Shard.html)'s parent shard id will be a string, not an index number. It makes no sense to compare to 0 using >.

Since the Kcl::Workers::ShardInfo#initialize sets nil values to 0 here, use `!= 0` to compare for the presence of the "missing value indicator".

We probably also want to review the decision to use 0 as an indicator, but this fixes an immediate issue causing a restart loop in bottling plant.
