### PR TITLE
Parent shard id is string, not numeric

### DIFF
--- a/lib/kcl/checkpointer.rb
+++ b/lib/kcl/checkpointer.rb
@@ -64,7 +64,7 @@ class Kcl::Checkpointer
       "#{DYNAMO_DB_LEASE_OWNER_KEY}" => shard.assigned_to,
       "#{DYNAMO_DB_LEASE_TIMEOUT_KEY}" => shard.lease_timeout.to_s
     }
-    if shard.parent_shard_id != 0
+    unless shard.parent_shard_id.nil?
       item[DYNAMO_DB_PARENT_SHARD_KEY] = shard.parent_shard_id
     end
 
@@ -117,7 +117,7 @@ class Kcl::Checkpointer
     if shard.checkpoint != ''
       item[DYNAMO_DB_CHECKPOINT_SEQUENCE_NUMBER_KEY] = shard.checkpoint
     end
-    if shard.parent_shard_id != 0
+    unless shard.parent_shard_id.nil?
       item[DYNAMO_DB_PARENT_SHARD_KEY] = shard.parent_shard_id
     end
 

--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end

--- a/lib/kcl/workers/shard_info.rb
+++ b/lib/kcl/workers/shard_info.rb
@@ -11,7 +11,7 @@ module Kcl::Workers
     # @param [Hash] sequence_number_range
     def initialize(shard_id, parent_shard_id, sequence_number_range)
       @shard_id        = shard_id
-      @parent_shard_id = parent_shard_id || 0
+      @parent_shard_id = parent_shard_id
       @starting_sequence_number = sequence_number_range[:starting_sequence_number]
       @ending_sequence_number   = sequence_number_range[:ending_sequence_number]
       @assigned_to     = nil


### PR DESCRIPTION
Change the logic around setting and checking for a default value for missing parent shard id to just use nil.

This is a follow on to https://github.com/Provi-Engineering/kcl-rb/commit/901477dce6b9df86d71c94cd740620e6e9e297ca which was a quick fix.