### PR TITLE
[IDL-166] Remove idle thread checks from consumer

### DIFF
--- a/lib/kcl/config.rb
+++ b/lib/kcl/config.rb
@@ -27,7 +27,6 @@ class Kcl::Config
     @dynamodb_read_capacity  = 10
     @dynamodb_write_capacity = 10
     @dynamodb_failover_seconds = 10
-    @idle_thread_check_frequency = 10
     @kinesis_endpoint        = 'https://localhost:4566'
     @kinesis_stream_name     = nil
     @logger                  = nil

--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.5'.freeze
+  VERSION = '1.0.6'.freeze
 end

--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -23,9 +23,6 @@ module Kcl::Workers
       shard_iterator = start_shard_iterator
 
       loop do
-        if check_peers?
-          break if idle_peers?
-        end
         result = safe_get_records(shard_iterator)
 
         records_input = create_records_input(
@@ -97,14 +94,6 @@ module Kcl::Workers
       shard_iterator = start_shard_iterator
       Kcl.logger.debug("Refreshed shard iterator, calling get records again")
       safe_get_records(shard_iterator, count - 1)
-    end
-
-    def check_peers?
-      Random.rand(Kcl.config.idle_thread_check_frequency).zero?
-    end
-
-    def idle_peers?
-      Thread.current.group.list.any?(&:stop?)
     end
   end
 end


### PR DESCRIPTION
https://teamprovi.atlassian.net/browse/IDL-166

Because of sharding (where parent shards are preserved indefinitely in the stream description) it's not productive to check for stopped peers to determine if this thread is racing ahead. The parent shards will be capped (set SHARD_END in the checkpoint) and their threads will stop immediately.

We'll be revisiting this again (hopefully with a timer or thread manager to restart finished threads when others are still processing) since the possibility of letting work accumulate while one thread stays busy draining a shard is still there, but the current work-around stopping busy threads is not a valid solution.
