### PR TITLE
Skip processing seen kinesis records

### DIFF
--- a/lib/kcl/version.rb
+++ b/lib/kcl/version.rb
@@ -1,3 +1,3 @@
 module Kcl
-  VERSION = '1.0.6'.freeze
+  VERSION = '1.0.7'.freeze
 end


### PR DESCRIPTION
After we recover from an expired iterator exception (in #safe_get_records), we repeat the request. 

This has led to reprocessing the same records multiple times, which is especially problematic after an expired iterator, since we then perform the same expensive operation (which can also timeout, restarting this cycle). 

Rather, remember the last [result](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Kinesis/Types/GetRecordsOutput.html) we had (in this shard's consumer thread), and only process new records after we request a batch. Use the record's [sequence number](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Kinesis/Types/Record.html#sequence_number-instance_method) to determine identity, since it's unique within the shard we're consuming.

